### PR TITLE
fix(securityhub): scope organization configuration to the aggregation region

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,14 @@ module "compliance" {
 }
 ```
 
+### Multi-Region Central Configuration
+
+Security Hub central configuration requires exactly one region — the aggregation
+region — to own the finding aggregator and organization configuration. Invoke this
+module once per region, setting `aggregator.create = true` and `specified_regions`
+only in the aggregation region; leave `securityhub` at its default in every linked
+region so it does not attempt to manage organization-level config.
+
 ### **Use Cases**
 
 #### **1. Enterprise Security Program**

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -223,3 +223,24 @@ module "compliance" {
     }
   }
 }
+
+module "compliance_us_east_1" {
+  source = "../.."
+
+  providers = {
+    aws = aws.audit_us_east_1
+  }
+
+  region = "us-east-1"
+
+  securityhub = {
+    notifications = {
+      enable     = true
+      severities = ["HIGH", "CRITICAL"]
+    }
+    # aggregator and configuration left at defaults (create = false, CENTRAL) —
+    # this region is linked, not the aggregation region
+  }
+
+  tags = local.tags
+}

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -9,8 +9,15 @@ locals {
     pci_dss                         = "arn:aws:securityhub:${local.region}::standards/pci-dss/v/3.2.1"
   }
 
+
+  ## Only the aggregation region (aggregator.create = true) may manage organization-level
+  ## Security Hub config when using CENTRAL configuration - AWS rejects these calls from
+  ## linked regions. LOCAL configuration is managed independently per region.
+
+  manage_organization_configuration = var.securityhub.configuration.organization_configuration.configuration_type == "LOCAL" ? true : var.securityhub.aggregator.create
+
   ## A list of policy associations
-  policy_associations_all = flatten([
+  policy_associations_all = local.manage_organization_configuration ? flatten([
     for policy_name, policy in var.securityhub.policies : [
       for association in policy.associations : {
         account             = association.account_id
@@ -20,7 +27,7 @@ locals {
         target_id           = coalesce(association.account_id, association.organization_unit)
       }
     ] if length(policy.associations) > 0
-  ])
+  ]) : []
 
   ## A map of all the policy associations by policy name
   policy_associations_by_policy = {
@@ -49,6 +56,8 @@ resource "aws_securityhub_finding_aggregator" "current" {
 
 ## Provision the organization configuration
 resource "aws_securityhub_organization_configuration" "current" {
+  count = local.manage_organization_configuration ? 1 : 0
+
   auto_enable           = var.securityhub.configuration.auto_enable
   auto_enable_standards = var.securityhub.configuration.auto_enable_standards
 
@@ -63,7 +72,7 @@ resource "aws_securityhub_organization_configuration" "current" {
 
 ## Provision one or more configuration policies for the security hub
 resource "aws_securityhub_configuration_policy" "current" {
-  for_each = var.securityhub.policies
+  for_each = local.manage_organization_configuration ? var.securityhub.policies : {}
 
   name        = each.key
   description = each.value.description

--- a/tests/module.tftest.hcl
+++ b/tests/module.tftest.hcl
@@ -21,6 +21,11 @@ run "basic" {
     error_message = "The security hub findings event bridge rule target is not set to sns"
   }
 
+  assert {
+    condition     = length(aws_securityhub_organization_configuration.current) == 1
+    error_message = "The aggregation region must manage the organization configuration"
+  }
+
   variables {
     region = "eu-west-2"
 
@@ -171,6 +176,38 @@ run "basic" {
         }
       }
     }
+  }
+}
+
+run "securityhub_linked_region" {
+  command = plan
+
+  assert {
+    condition     = length(aws_securityhub_organization_configuration.current) == 0
+    error_message = "A linked region must not manage the organization configuration"
+  }
+
+  assert {
+    condition     = length(aws_securityhub_configuration_policy.current) == 0
+    error_message = "A linked region must not manage configuration policies"
+  }
+
+  assert {
+    condition     = length(aws_securityhub_configuration_policy_association.current) == 0
+    error_message = "A linked region must not manage configuration policy associations"
+  }
+
+  variables {
+    region = "us-east-1"
+
+    tags = {
+      Project     = "Demo"
+      Environment = "Development"
+      Terraform   = "true"
+    }
+
+    # securityhub omitted -> defaults to aggregator.create = false,
+    # configuration_type = "CENTRAL" (the linked-region case)
   }
 }
 


### PR DESCRIPTION
### Summary

- Security Hub central configuration requires exactly one region (the aggregation region) to manage aws_securityhub_organization_configuration, configuration policies, and their associations — AWS rejects those calls from any other region. The module previously created them unconditionally in every regional invocation, so linked-region calls always failed (ResourceNotFoundException / ResourceConflictException / AccessDeniedException depending on the workaround attempted).
- Gate those three resources behind a new manage_organization_configuration local, which reuses the existing aggregator. Create a flag as the "is this the aggregation region" signal (AWS only permits one finding aggregator org-wide, created in the aggregation region) - no new variable needed, and LOCAL configuration keeps working per-region as before.
- Add qa terraform test run covering the linked-region case, a second compliance_us_east_1 example call, and README guidance on invoking the module once per region.

### Test plan

- Ran in a real world scenario in appvia-lz-aws-dev pointing to the bug branch [appvia-lz-aws-dev/lz-aws-compliance](https://github.com/appvia-lz-aws-dev/lz-aws-compliance/actions/runs/31048242315/job/92449255587 )